### PR TITLE
added priority option to reminders 

### DIFF
--- a/AutolayoutPractice/RemindersList/Model/Reminder.swift
+++ b/AutolayoutPractice/RemindersList/Model/Reminder.swift
@@ -12,4 +12,5 @@ struct Reminder: Codable {
     var description: String
     var dueDate: Date
     var completed: Bool
+    var isPriority: Bool
 }

--- a/AutolayoutPractice/RemindersList/ViewModel/RemindersViewModel.swift
+++ b/AutolayoutPractice/RemindersList/ViewModel/RemindersViewModel.swift
@@ -10,16 +10,16 @@ import Foundation
 class RemindersViewModel {
     var reminders: [Reminder] = []
 
-    func addReminder(title: String, description: String, dueDate: Date) {
-        let newReminder = Reminder(title: title, description: description, dueDate: dueDate, completed: false)
+    func addReminder(title: String, description: String, dueDate: Date, isPriority: Bool) {
+        let newReminder = Reminder(title: title, description: description, dueDate: dueDate, completed: false, isPriority: isPriority)
         reminders.insert(newReminder, at: 0)
     }
 
     private func createReminders() {
-        reminders.append(Reminder(title: "Pick up groceries", description: "At Whole Foods", dueDate: Date(), completed: false))
-        reminders.append(Reminder(title: "Call Jane", description: "Her new num - 888-888-8888, remind her about the recital on Saturday", dueDate: Date(), completed: false))
-        reminders.append(Reminder(title: "Schedule Drs. Appt", description: "First week of July", dueDate: Date(), completed: false))
-        reminders.append(Reminder(title: "RSVP for Danny's Dance Recital", description: "RSVP for 3 people", dueDate: Date(), completed: false))
-        reminders.append(Reminder(title: "Call insurance company", description: "Make sure the have full coverage", dueDate: Date(), completed: false))
+        reminders.append(Reminder(title: "Pick up groceries", description: "At Whole Foods", dueDate: Date(), completed: false, isPriority: false))
+        reminders.append(Reminder(title: "Call Jane", description: "Her new num - 888-888-8888, remind her about the recital on Saturday", dueDate: Date(), completed: false, isPriority: true))
+        reminders.append(Reminder(title: "Schedule Drs. Appt", description: "First week of July", dueDate: Date(), completed: false, isPriority: true))
+        reminders.append(Reminder(title: "RSVP for Danny's Dance Recital", description: "RSVP for 3 people", dueDate: Date(), completed: false, isPriority: false))
+        reminders.append(Reminder(title: "Call insurance company", description: "Make sure the have full coverage", dueDate: Date(), completed: false, isPriority: true))
     }
 }

--- a/AutolayoutPractice/RemindersList/Views/AddReminderViewController.swift
+++ b/AutolayoutPractice/RemindersList/Views/AddReminderViewController.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 protocol AddReminderDelegate: AnyObject {
-    func addReminder(title: String, description: String, dueDate: Date)
+    func addReminder(title: String, description: String, dueDate: Date, isPriority: Bool)
 }
 
 class AddReminderViewController: UIViewController {
@@ -46,6 +46,7 @@ class AddReminderViewController: UIViewController {
         let lbl = UILabel()
         lbl.translatesAutoresizingMaskIntoConstraints = false
         lbl.text = "Add details for your reminder"
+        lbl.font = .preferredFont(forTextStyle: .callout)
         return lbl
     }()
 
@@ -57,6 +58,19 @@ class AddReminderViewController: UIViewController {
         textView.layer.borderWidth = 1
         textView.font = .preferredFont(forTextStyle: .body)
         return textView
+    }()
+
+    private let priorityLabel: UILabel = {
+        let lbl = UILabel()
+        lbl.translatesAutoresizingMaskIntoConstraints = false
+        lbl.text = "Mark as important?"
+        return lbl
+    }()
+
+    private let priorityToggle: UISwitch = {
+        let uiSwitch = UISwitch()
+        uiSwitch.translatesAutoresizingMaskIntoConstraints = false
+        return uiSwitch
     }()
 
     private let dueDatePicker: UIDatePicker = {
@@ -82,7 +96,7 @@ class AddReminderViewController: UIViewController {
     }
 
     @objc private func saveAction() {
-        delegate?.addReminder(title: titleTextField.text ?? "", description: descriptionTextView.text ?? "", dueDate: dueDatePicker.date)
+        delegate?.addReminder(title: titleTextField.text ?? "", description: descriptionTextView.text ?? "", dueDate: dueDatePicker.date, isPriority: priorityToggle.isOn )
         dismiss(animated: true)
     }
 
@@ -96,6 +110,8 @@ class AddReminderViewController: UIViewController {
         view.addSubview(titleTextField)
         view.addSubview(descriptionLabel)
         view.addSubview(descriptionTextView)
+        view.addSubview(priorityLabel)
+        view.addSubview(priorityToggle)
         view.addSubview(dueDatePicker)
 
         NSLayoutConstraint.activate([
@@ -103,16 +119,20 @@ class AddReminderViewController: UIViewController {
             cancelButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
             saveButton.topAnchor.constraint(equalTo: view.topAnchor, constant: 15),
             saveButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
-            titleTextField.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 30),
+            titleTextField.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
             titleTextField.topAnchor.constraint(equalTo: cancelButton.bottomAnchor, constant: 30),
             titleTextField.widthAnchor.constraint(equalTo: view.widthAnchor, multiplier: 0.7),
             descriptionLabel.leadingAnchor.constraint(equalTo: titleTextField.leadingAnchor),
             descriptionLabel.topAnchor.constraint(equalTo: titleTextField.bottomAnchor, constant: 25),
             descriptionTextView.leadingAnchor.constraint(equalTo: descriptionLabel.leadingAnchor),
-            descriptionTextView.topAnchor.constraint(equalTo: descriptionLabel.bottomAnchor, constant: 7),
+            descriptionTextView.topAnchor.constraint(equalTo: descriptionLabel.bottomAnchor, constant: 4),
             descriptionTextView.widthAnchor.constraint(equalTo: view.widthAnchor, multiplier: 0.7),
             descriptionTextView.heightAnchor.constraint(equalTo: view.heightAnchor, multiplier: 0.1),
-            dueDatePicker.topAnchor.constraint(equalTo: descriptionTextView.bottomAnchor, constant: 30),
+            priorityLabel.topAnchor.constraint(equalTo: descriptionTextView.bottomAnchor, constant: 27),
+            priorityLabel.leadingAnchor.constraint(equalTo: descriptionTextView.leadingAnchor),
+            priorityToggle.topAnchor.constraint(equalTo: priorityLabel.topAnchor),
+            priorityToggle.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -25),
+            dueDatePicker.topAnchor.constraint(equalTo: priorityLabel.bottomAnchor, constant: 20),
             dueDatePicker.leadingAnchor.constraint(equalTo: titleTextField.leadingAnchor)
         ])
     }

--- a/AutolayoutPractice/RemindersList/Views/ReminderCell/ReminderCell.swift
+++ b/AutolayoutPractice/RemindersList/Views/ReminderCell/ReminderCell.swift
@@ -22,6 +22,7 @@ class ReminderCell: UITableViewCell {
         title.text = reminder.title
         summary.text = reminder.description
         dueDate.text = reminder.dueDateString
+        prioritySymbol.isHidden = !reminder.isPriority
     }
 
     private let title: UILabel = {
@@ -44,6 +45,14 @@ class ReminderCell: UITableViewCell {
         return lbl
     }()
 
+    private let prioritySymbol: UIImageView = {
+        let img = UIImage(systemName: "exclamationmark.bubble.fill")
+        let imageView = UIImageView(image: img)
+        imageView.tintColor = .red
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        return imageView
+    }()
+
     private let dueDate: UILabel = {
         let lbl = UILabel()
         lbl.translatesAutoresizingMaskIntoConstraints = false
@@ -64,21 +73,21 @@ class ReminderCell: UITableViewCell {
 
     private func configure() {
 
-        contentView.addSubview(title)
+        let stack = UIStackView(arrangedSubviews: [title, summary])
+        stack.axis = .vertical
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(stack)
         contentView.addSubview(dueDate)
-        contentView.addSubview(summary)
+        contentView.addSubview(prioritySymbol)
+
         NSLayoutConstraint.activate([
-            title.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20),
-            title.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 10),
-            title.widthAnchor.constraint(equalTo: contentView.widthAnchor, multiplier: 0.7),
-
-            summary.topAnchor.constraint(equalTo: title.bottomAnchor, constant: 10),
-            summary.leadingAnchor.constraint(equalTo: title.leadingAnchor),
-            summary.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -10),
-            summary.widthAnchor.constraint(equalTo: contentView.widthAnchor, multiplier: 0.7),
-
-            dueDate.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -10),
-            dueDate.centerYAnchor.constraint(equalTo: contentView.centerYAnchor)
+            stack.leadingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.leadingAnchor),
+            stack.centerYAnchor.constraint(equalTo: contentView.layoutMarginsGuide.centerYAnchor),
+            dueDate.trailingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.trailingAnchor, constant: -10),
+            dueDate.centerYAnchor.constraint(equalTo: contentView.layoutMarginsGuide.centerYAnchor),
+            prioritySymbol.topAnchor.constraint(equalTo: dueDate.bottomAnchor, constant: 10),
+            prioritySymbol.trailingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.trailingAnchor, constant: -10),
+            prioritySymbol.bottomAnchor.constraint(equalTo: contentView.layoutMarginsGuide.bottomAnchor, constant: -15)
         ])
     }
 }

--- a/AutolayoutPractice/RemindersList/Views/ReminderCell/ReminderCellConfiguration.swift
+++ b/AutolayoutPractice/RemindersList/Views/ReminderCell/ReminderCellConfiguration.swift
@@ -11,4 +11,5 @@ struct ReminderCellConfiguration {
     let title: String
     let description: String
     let dueDateString: String
+    let isPriority: Bool
 }

--- a/AutolayoutPractice/RemindersList/Views/RemindersListViewController.swift
+++ b/AutolayoutPractice/RemindersList/Views/RemindersListViewController.swift
@@ -9,8 +9,8 @@ import Foundation
 import UIKit
 
 class RemindersListViewController: UIViewController, AddReminderDelegate {
-    func addReminder(title: String, description: String, dueDate: Date) {
-        viewModel.addReminder(title: title, description: description, dueDate: dueDate)
+    func addReminder(title: String, description: String, dueDate: Date, isPriority: Bool) {
+        viewModel.addReminder(title: title, description: description, dueDate: dueDate, isPriority: isPriority)
         reloadTableView()
     }
 
@@ -87,7 +87,7 @@ extension RemindersListViewController: UITableViewDelegate, UITableViewDataSourc
             return UITableViewCell()
         }
         let reminder = viewModel.reminders[indexPath.row]
-        cell.configuration = ReminderCellConfiguration(title: reminder.title, description: reminder.description, dueDateString: reminder.dueDate.formatted(date: .numeric, time: .omitted))
+        cell.configuration = ReminderCellConfiguration(title: reminder.title, description: reminder.description, dueDateString: reminder.dueDate.formatted(date: .numeric, time: .omitted), isPriority: reminder.isPriority)
 
         return cell
     }


### PR DESCRIPTION
added priority flag to reminder model
adjusted cell layout

A priority flag is meant to give the user a way to mark their reminder as "important" and provide visual indicator to ensure the user's attention is drawn to "must do" reminders. Additionally it will be useful in the future when push notifications are added because we may use this property to create custom alerts